### PR TITLE
with-transaction: accept the same arguments as clojure.java.jdbc/with-db-transaction

### DIFF
--- a/src/conman/core.clj
+++ b/src/conman/core.clj
@@ -73,10 +73,13 @@
   (connect! conn pool-spec))
 
 (defmacro with-transaction
-  "runs the body in a transaction where t-conn is the name of the transaction connection
-   the body will be evaluated within a binding where conn is set to the transactional
-   connection"
+  "Runs the body in a transaction where t-conn is the name of the transaction connection.
+   The body will be evaluated within a binding where conn is set to the transactional
+   connection. The isolation level and readonly status of the transaction may also be specified.
+   (with-db-transaction [t-conn conn :isolation level :read-only? true]
+     ... t-conn ...)
+   See clojure.java.jdbc/db-transaction* for more details."
   [args & body]
-  `(clojure.java.jdbc/with-db-transaction [~(first args) (deref ~(second args))]
+  `(clojure.java.jdbc/with-db-transaction [~(first args) (deref ~(second args)) ~@(rest (rest args))]
                                           (binding [~(second args) (atom ~(first args))]
                                             ~@body)))

--- a/test/conman/core_test.clj
+++ b/test/conman/core_test.clj
@@ -49,3 +49,12 @@
      (= []
         (get-fruit {:name "apple"}))))
 
+(deftest transaction-options
+  (with-transaction
+    [t-conn conn :isolation :serializable]
+    (is (= java.sql.Connection/TRANSACTION_SERIALIZABLE
+           (.getTransactionIsolation (sql/db-connection t-conn)))))
+  (with-transaction
+    [t-conn conn :isolation :read-uncommitted]
+    (is (= java.sql.Connection/TRANSACTION_READ_UNCOMMITTED
+           (.getTransactionIsolation (sql/db-connection t-conn))))))


### PR DESCRIPTION
This pull request makes it possible to configure the isolation level and readonly status of the transaction.
