### PR TITLE
Added arity to conman queries for processor options

### DIFF
--- a/src/conman/core.clj
+++ b/src/conman/core.clj
@@ -23,7 +23,9 @@
                              (fn
                                ([] (yesql-query# {} {:connection (deref ~conn)}))
                                ([args#] (yesql-query# args# {:connection (deref ~conn)}))
-                               ([args# conn#] (yesql-query# args# {:connection conn#})))))))))]
+                               ([args# conn#] (yesql-query# args# {:connection conn#}))
+                               ([args# conn# options#]
+                                (yesql-query# args# (merge {:connection conn#} options#))))))))))]
        (in-ns (ns-name base-namespace#))
        yesql-connected-queries#)))
 


### PR DESCRIPTION
The query functions produced in bind-connection can
now accept an option map as a third argument,
which enables support for yesql processor functions
(e.g., :result-set-fn, :row-fn, :identifiers)
from conman queries.
