### PR TITLE
drop unneeded dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,10 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [clj-dbcp "0.8.1"]
                  [com.zaxxer/HikariCP "2.4.2"]
                  [yesql "0.5.1"]
-                 [instaparse "1.4.1"]
                  [com.carouselapps/to-jdbc-uri "0.4.1"]
                  [org.clojure/java.jdbc "0.4.2"]]
   :profiles


### PR DESCRIPTION
clj-dbcp is obsoleted by hikaricp.
yesql 0.5.1 already depends on instaparse 1.4.1.
