### PR TITLE
Fix HugSQL snippet usage

### DIFF
--- a/src/conman/core.clj
+++ b/src/conman/core.clj
@@ -20,7 +20,7 @@
       (let [{snips true
              fns   false}
             (group-by
-              #(-> % second :snip? boolean)
+              #(-> % second :meta :snip? boolean)
               (hugsql/map-of-db-fns file))]
         (-> queries
             (update :snips into snips)

--- a/test/conman/core_test.clj
+++ b/test/conman/core_test.clj
@@ -94,3 +94,15 @@
     [conn {:isolation :read-uncommitted}]
     (is (= java.sql.Connection/TRANSACTION_READ_UNCOMMITTED
            (.getTransactionIsolation (sql/db-connection conn))))))
+
+(deftest hugsql-snippets
+  (is (= 1
+         (add-fruit!
+          {:name "orange"
+           :appearance "orange"
+           :cost 1
+           :grade 1})))
+  (is (= "orange"
+         (:name
+          (get-fruit-by {:by-appearance
+                         (by-appearance {:appearance "orange"})})))))

--- a/test/queries.sql
+++ b/test/queries.sql
@@ -8,3 +8,10 @@ VALUES
 -- :doc gets fruit by name
 SELECT * FROM fruits
 WHERE name = :name
+
+-- :snip by-appearance
+appearance = :appearance
+
+-- :name get-fruit-by :? :1
+SELECT * FROM fruits
+WHERE :snip:by-appearance


### PR DESCRIPTION
Reference: [HugSQL Issue #50](https://github.com/layerware/hugsql/issues/50)

Looks like this was broken since the beginning of conman+HugSQL.

(In order to run the test suite I had to downgrade to `hikari-cp 1.7.0` because of it complaining about `:jdbc-url`)
