### PR TITLE
Cleanup

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,4 +10,4 @@
                  [hikari-cp "1.7.5"]]
   :profiles
   {:dev
-   {:dependencies [[com.h2database/h2 "1.4.191"]]}})
+   {:dependencies [[com.h2database/h2 "1.4.195"]]}})

--- a/src/conman/core.clj
+++ b/src/conman/core.clj
@@ -1,12 +1,10 @@
 (ns conman.core
-  (:require [to-jdbc-uri.core :refer [to-jdbc-uri]]
-            [hugsql.core :as hugsql]
-            [clojure.java.io :as io]
-            [org.tobereplaced.lettercase :refer [mixed-name]]
-            [hikari-cp.core :refer [make-datasource datasource-config BaseConfigurationOptions]]
+  (:require [clojure.java.io :as io]
+            clojure.java.jdbc
             [clojure.set :refer [rename-keys]]
-            clojure.java.jdbc)
-  (:import [com.zaxxer.hikari HikariDataSource]))
+            [hikari-cp.core :refer [datasource-config make-datasource]]
+            [hugsql.core :as hugsql]
+            [to-jdbc-uri.core :refer [to-jdbc-uri]]))
 
 (defn validate-files [filenames]
   (doseq [file filenames]
@@ -68,7 +66,7 @@
   "attempts to create a new connection and set it as the value of the conn atom,
    does nothing if conn atom is already populated"
   [pool-spec]
-  {:datasource (HikariDataSource. (make-config pool-spec))})
+  {:datasource (make-datasource (make-config pool-spec))})
 
 (defn disconnect!
   "checks if there's a connection and closes it


### PR DESCRIPTION
Had a look at how `conman` does its macro work and saw that it was using `HikariDataSource.`, when it could use `make-datasource`.

Then cleaned up the rest of the namespace and upgraded h2.