### PR TITLE
make-datasource already calls datasource-config so remove

### DIFF
--- a/src/conman/core.clj
+++ b/src/conman/core.clj
@@ -53,14 +53,13 @@
 (defn make-config [{:keys [jdbc-url adapter datasource datasource-classname] :as pool-spec}]
   (when (not (or jdbc-url adapter datasource datasource-classname))
     (throw (Exception. "one of :jdbc-url, :adapter, :datasource, or :datasource-classname is required to initialize the connection!")))
-  (datasource-config
-    (-> pool-spec
-        (format-url)
-        (rename-keys
-         {:auto-commit?  :auto-commit
-          :conn-timeout  :connection-timeout
-          :min-idle      :minimum-idle
-          :max-pool-size :maximum-pool-size}))))
+  (-> pool-spec
+      (format-url)
+      (rename-keys
+       {:auto-commit?  :auto-commit
+        :conn-timeout  :connection-timeout
+        :min-idle      :minimum-idle
+        :max-pool-size :maximum-pool-size})))
 
 (defn connect!
   "attempts to create a new connection and set it as the value of the conn atom,

--- a/test/conman/core_test.clj
+++ b/test/conman/core_test.clj
@@ -44,7 +44,7 @@
 (deftest datasource
   (is
     (instance?
-      com.zaxxer.hikari.HikariConfig
+     clojure.lang.PersistentArrayMap
       (make-config
         {:jdbc-url "jdbc:h2:./test.db"
          :datasource-classname "org.h2.Driver"}))))
@@ -52,7 +52,7 @@
 (deftest datasource-classname
   (is
     (instance?
-      com.zaxxer.hikari.HikariConfig
+     clojure.lang.PersistentArrayMap
       (make-config
         {:datasource-classname "org.h2.Driver"
          :jdbc-url "jdbc:h2:./test.db"}))))
@@ -60,7 +60,7 @@
 (deftest jdbc-url
   (is
     (instance?
-      com.zaxxer.hikari.HikariConfig
+      clojure.lang.PersistentArrayMap
       (make-config
         {:jdbc-url "jdbc:h2:./test.db"}))))
 


### PR DESCRIPTION
I was tracking down a problem where my MetricRegistry does not have any database metrics even though I pass it in with the pool spec.   hikari-cp make-datasource calls datasource-config already,  and expects a pool-spec, not a HikariConfig, so it is not needed to call it in make-config unless I am missing something. 