### PR TITLE
Updates hikari-cp to version 1.8.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [com.layerware/hugsql "0.4.7"]
                  [com.carouselapps/to-jdbc-uri "0.5.0"]
                  [org.clojure/java.jdbc "0.6.1"]
-                 [hikari-cp "1.7.6"]]
+                 [hikari-cp "1.8.1"]]
   :profiles
   {:dev
    {:dependencies [[com.h2database/h2 "1.4.196"]]}})


### PR DESCRIPTION
When using `conman 0.6.8` with `clojure-1.9.0-beta2` I get the following warning:
`WARNING: Inst already refers to: #'clojure.core/Inst in namespace: schema.core, being replaced by: #'schema.core/Inst`.

It seems that `hikari-cp 1.7.6` uses `schema 1.0.4` that doesn't exclude `clojure.core/Inst`. 
Upgrading to `hikari-cp 1.8.1` which uses `schema 1.1.6` solves the issue.