### PR TITLE
Support derefable states in bind-connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ in the current namespace. These functions can be called in four different ways:
 
 ```
 
+Alternatively, if you prefer `:cljc` mode of mount, where you would need to explicitly `deref` each state,
+you can use the following form:
+
+```clojure
+(mount/in-cljc-mode)
+
+(conman/bind-connection #(deref *db*) "sql/queries.sql")
+```
+
 Next, the `connect!` function should be called to initialize the database connection.
 The function accepts a map with the database specification.
 

--- a/src/conman/core.clj
+++ b/src/conman/core.clj
@@ -64,14 +64,14 @@
        (doseq [[id# {fn# :fn {doc# :doc} :meta}] fns#]
          (intern *ns* (with-meta (symbol (name id#)) {:doc doc#})
                  (fn f#
-                   ([] (f# ~conn {}))
-                   ([params#] (f# ~conn params#))
+                   ([] (f# (if (fn? ~conn) (~conn) ~conn) {}))
+                   ([params#] (f# (if (fn? ~conn) (~conn) ~conn) params#))
                    ([conn# params#]
-                    (try (fn# conn# params#)
+                    (try (fn# (if (fn? conn#) (conn#) conn#) params#)
                          (catch Exception e#
                            (throw (Exception. (format "Exception in %s" id#) e#)))))
                    ([conn# params# opts# & command-opts#]
-                    (try (apply fn# conn# params# opts# command-opts#)
+                    (try (apply fn# (if (fn? conn#) (conn#) conn#) params# opts# command-opts#)
                          (catch Exception e#
                            (throw (Exception. (format "Exception in %s" id#) e#))))))))
        queries#)))


### PR DESCRIPTION
I'd like to add a small feature.
I feel that using `:cljc` mode of mount adds some safety, where you cannot accidentally touch a stopped state.
Therefore, I propose a change that would make `bind-connection` compatible with this mode.
Unfortunately, I don't see a way to easily test this option, but it's quite simple and does not break the existing functionality.
Thanks in advance.