### PR TITLE
Don't rely on (instance? IDeref ...) in bind-connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,14 @@ in the current namespace. These functions can be called in four different ways:
 ```
 
 If you use `:cljc` [mode of mount](https://github.com/tolitius/mount/blob/master/doc/clojurescript.md#clojure-and-clojurescript-mode),
-where you would need to explicitly `deref` each state,
-`conman/bind-connection` and `conman/with-transaction` macros still accept undereferenced state,
+where you would need to explicitly `deref` each state, you'll need to use `conman/bind-connection-deref` instead of
+`conman/bind-connection`. Both `conman/bind-connection-deref` and `conman/with-transaction` macros still accept undereferenced state,
 while in every other case it has to be dereferenced:
 
 ```clojure
 (mount/in-cljc-mode)
 
-(conman/bind-connection *db* "sql/queries.sql")
+(conman/bind-connection-deref *db* "sql/queries.sql")
 
 (conman/with-transaction [*db*]
   (sql/db-set-rollback-only! @*db*)

--- a/project.clj
+++ b/project.clj
@@ -10,4 +10,5 @@
                  [hikari-cp "1.8.1"]]
   :profiles
   {:dev
-   {:dependencies [[com.h2database/h2 "1.4.196"]]}})
+   {:dependencies [[com.h2database/h2 "1.4.196"]
+                   [mount "0.1.11"]]}})

--- a/test/conman/core2_test.clj
+++ b/test/conman/core2_test.clj
@@ -3,15 +3,16 @@
   (:require [clojure.test :refer :all]
             [conman.core :refer :all]
             [clojure.java.jdbc :as sql]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [mount.core :as m]))
 
-(defonce ^:dynamic conn
-         (delay {:connection-uri "jdbc:h2:./test.db"
-                 :make-pool?     true
-                 :naming         {:keys   clojure.string/lower-case
-                                  :fields clojure.string/upper-case}}))
+(m/defstate ^:dynamic conn2
+  :start {:connection-uri "jdbc:h2:./test.db"
+          :make-pool?     true
+          :naming         {:keys   clojure.string/lower-case
+                           :fields clojure.string/upper-case}})
 
-(bind-connection conn "queries.sql")
+(bind-connection conn2 "queries.sql")
 
 (defn delete-test-db []
   (io/delete-file "test.db.mv.db" true)
@@ -19,7 +20,7 @@
 
 (defn create-test-table []
   (sql/db-do-commands
-    @conn
+    @conn2
     ["DROP TABLE fruits IF EXISTS;"
      (sql/create-table-ddl
        :fruits
@@ -33,14 +34,17 @@
 (use-fixtures
   :once
   (fn [f]
+    (m/in-cljc-mode)
+    (m/start #'conn2)
     (delete-test-db)
     (create-test-table)
-    (f)))
+    (f)
+    (m/stop)))
 
 (deftest transaction
   (with-transaction
-    [conn]
-    (sql/db-set-rollback-only! @conn)
+    [conn2]
+    (sql/db-set-rollback-only! @conn2)
     (is
       (= 1
          (add-fruit!

--- a/test/conman/core2_test.clj
+++ b/test/conman/core2_test.clj
@@ -12,7 +12,7 @@
           :naming         {:keys   clojure.string/lower-case
                            :fields clojure.string/upper-case}})
 
-(bind-connection conn2 "queries.sql")
+(bind-connection-deref conn2 "queries.sql")
 
 (defn delete-test-db []
   (io/delete-file "test.db.mv.db" true)

--- a/test/conman/core_test.clj
+++ b/test/conman/core_test.clj
@@ -3,10 +3,12 @@
             [conman.core :refer :all]
             [clojure.java.jdbc :as sql]
             [clojure.repl :refer [doc]]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [mount.core :as m])
+  (:import (clojure.lang IDeref)))
 
-(defonce ^:dynamic conn
-         {:connection-uri "jdbc:h2:./test.db"
+(m/defstate ^:dynamic conn
+  :start {:connection-uri "jdbc:h2:./test.db"
           :make-pool?     true
           :naming         {:keys   clojure.string/lower-case
                            :fields clojure.string/upper-case}})
@@ -33,9 +35,12 @@
 (use-fixtures
   :once
   (fn [f]
+    (m/in-clj-mode)
+    (m/start #'conn)
     (delete-test-db)
     (create-test-table)
-    (f)))
+    (f)
+    (m/stop)))
 
 (deftest doc-test
   (is (= "-------------------------\nconman.core-test/get-fruit\n  gets fruit by name\n"
@@ -100,9 +105,9 @@
             :cost       1
             :grade      1})))
   (is (= "orange"
-         (:name
-           (get-fruit-by {:by-appearance
-                          (by-appearance {:appearance "orange"})})))))
+           (:name
+             (get-fruit-by {:by-appearance
+                            (by-appearance {:appearance "orange"})})))))
 
 
 


### PR DESCRIPTION
Closes #49.

Right after `defstate` mount states are of type `mount.core.DerefableState` that implements `IDeref`, no matter whether `:cljc` mode is on or off.
This is how `bind-connection` sees it when it's called to generate functions from `queries.sql`, making them call `deref` on the connection every time.

In the  default `:clj` mode after the first start a state turns into the real value, which, in case of database connections, is not `IDeref`, just a plain map.
After the stop, it turns into `mount.core.NotStartedState`, which is also not `IDeref`.

I used mount in tests to reproduce this situation.