### PR TITLE
Instead of discarding non-doc metadata from hugsql, attach it to the vars.

### DIFF
--- a/src/conman/core.clj
+++ b/src/conman/core.clj
@@ -56,14 +56,14 @@
         options   (if options? (first filenames) {})
         filenames (if options? (rest filenames) filenames)]
     `(let [{snips# :snips fns# :fns :as queries#} (conman.core/load-queries '~filenames ~options)]
-       (doseq [[id# {fn# :fn {doc# :doc} :meta}] snips#]
-         (intern *ns* (with-meta (symbol (name id#)) {:doc doc#})
+       (doseq [[id# {fn# :fn meta# :meta}] snips#]
+         (intern *ns* (with-meta (symbol (name id#)) meta#)
                  (fn [& args#]
                    (try (apply fn# args#)
                         (catch Exception e#
                           (throw (Exception. (format "Exception in %s" id#) e#)))))))
-       (doseq [[id# {fn# :fn {doc# :doc} :meta}] fns#]
-         (intern *ns* (with-meta (symbol (name id#)) {:doc doc#})
+       (doseq [[id# {fn# :fn meta# :meta}] fns#]
+         (intern *ns* (with-meta (symbol (name id#)) meta#)
                  (fn f#
                    ([] (f# ~conn {}))
                    ([params#] (f# ~conn params#))
@@ -82,14 +82,14 @@
         options   (if options? (first filenames) {})
         filenames (if options? (rest filenames) filenames)]
     `(let [{snips# :snips fns# :fns :as queries#} (conman.core/load-queries '~filenames ~options)]
-       (doseq [[id# {fn# :fn {doc# :doc} :meta}] snips#]
+       (doseq [[id# {fn# :fn meta# :meta}] snips#]
          (intern *ns* (with-meta (symbol (name id#)) {:doc doc#})
                  (fn [& args#]
                    (try (apply fn# args#)
                         (catch Exception e#
                           (throw (Exception. (format "Exception in %s" id#) e#)))))))
-       (doseq [[id# {fn# :fn {doc# :doc} :meta}] fns#]
-         (intern *ns* (with-meta (symbol (name id#)) {:doc doc#})
+       (doseq [[id# {fn# :fn meta# :meta}] fns#]
+         (intern *ns* (with-meta (symbol (name id#)) meta#)
                  (fn f#
                    ([] (f# (deref ~conn) {}))
                    ([params#] (f# (deref ~conn) params#))


### PR DESCRIPTION
This will allow us to take advantage of https://github.com/layerware/hugsql/pull/78
which will let conman-defined SQL functions work with all your
standard jump-to-definition commands of any editor or IDE.