### PR TITLE
Fix missing evaluation of connection options

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject conman "0.8.2"
+(defproject conman "0.8.3-SNAPSHOT"
   :description "a database connection management library"
   :url "https://github.com/luminus-framework/conman"
   :license {:name "Eclipse Public License"

--- a/src/conman/core.clj
+++ b/src/conman/core.clj
@@ -35,7 +35,7 @@
                      (catch Exception e
                        (throw (Exception. (str "Exception in " id) e))))))))])
 
-(defn load-queries [args]
+(defn load-queries [& args]
   (let [options? (map? (first args))
         options (if options? (first args) {})
         filenames (if options? (rest args) args)]
@@ -57,7 +57,7 @@
   (intern ns (with-meta (symbol (name id)) meta) f))
 
 (defmacro bind-connection [conn & filenames]
-  `(let [{snips# :snips fns# :fns :as queries#} (conman.core/load-queries '~filenames)]
+  `(let [{snips# :snips fns# :fns :as queries#} (conman.core/load-queries ~@filenames)]
      (doseq [[id# {fn# :fn meta# :meta}] snips#]
        (conman.core/intern-fn *ns* id# meta# fn#))
      (doseq [[id# {query# :fn meta# :meta}] fns#]
@@ -69,7 +69,7 @@
      queries#))
 
 (defmacro bind-connection-deref [conn & filenames]
-  `(let [{snips# :snips fns# :fns :as queries#} (conman.core/load-queries '~filenames)]
+  `(let [{snips# :snips fns# :fns :as queries#} (conman.core/load-queries ~@filenames)]
      (doseq [[id# {fn# :fn meta# :meta}] snips#]
        (conman.core/intern-fn *ns* id# meta# fn#))
      (doseq [[id# {query# :fn meta# :meta}] fns#]
@@ -81,7 +81,7 @@
      queries#))
 
 (defn bind-connection-map [conn & args]
-  (-> (load-queries args)
+  (-> (apply load-queries args)
       (update :snips
               (fn [snips]
                 (reduce (fn [acc [id snip]] (assoc acc id snip)) {} snips)))

--- a/test/conman/core_test.clj
+++ b/test/conman/core_test.clj
@@ -110,7 +110,7 @@
                           (by-appearance {:appearance "orange"})})))))
 
 (deftest explicit-queries
-  (let [queries (load-queries ["queries.sql"])]
+  (let [queries (load-queries "queries.sql")]
     (is (= 1
            (query conn
                   queries


### PR DESCRIPTION
Fix as discussed in #62. Works in my use case and given the small scope should be pretty safe.