### PR TITLE
fix :arglists metadata for generated functions

### DIFF
--- a/src/conman/core.clj
+++ b/src/conman/core.clj
@@ -66,7 +66,11 @@
      (doseq [[id# {fn# :fn meta# :meta}] snips#]
        (conman.core/intern-fn *ns* id# meta# fn#))
      (doseq [[id# {query# :fn meta# :meta}] fns#]
-       (conman.core/intern-fn *ns* id# meta#
+       (conman.core/intern-fn *ns* id#
+                              ;; Need to explicitly set :arglists since we don't use defn.
+                              ;; Another option would be to generate defns.
+                              (assoc meta#
+                                     :arglists (quote ~'([] [params] [db params options & command-options])))
                               (fn f#
                                 ([] (query# ~conn {}))
                                 ([params#] (query# ~conn params#))
@@ -78,7 +82,9 @@
      (doseq [[id# {fn# :fn meta# :meta}] snips#]
        (conman.core/intern-fn *ns* id# meta# fn#))
      (doseq [[id# {query# :fn meta# :meta}] fns#]
-       (conman.core/intern-fn *ns* id# meta#
+       (conman.core/intern-fn *ns* id#
+                              (assoc meta#
+                                     :arglists (quote ~'([] [params] [db params options & command-options])))
                               (fn f#
                                 ([] (query# (deref ~conn) {}))
                                 ([params#] (query# (deref ~conn) params#))

--- a/test/conman/core_test.clj
+++ b/test/conman/core_test.clj
@@ -43,7 +43,7 @@
     (m/stop)))
 
 (deftest doc-test
-  (is (= "-------------------------\nconman.core-test/get-fruit\n([db] [db params] [db params options & command-options])\n  gets fruit by name\n"
+  (is (= "-------------------------\nconman.core-test/get-fruit\n([] [params] [db params options & command-options])\n  gets fruit by name\n"
          (with-out-str (doc get-fruit)))))
 
 (deftest datasource


### PR DESCRIPTION
the metadata from hugsql was getting passed on as-is, which mean that
the arglists still contained the db argument