### PR TITLE
Use hugsql-core to exclude java.jdbc package

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [com.layerware/hugsql "0.5.1"]
+                 [com.layerware/hugsql-core "0.5.1"]
                  [com.layerware/hugsql-adapter-next-jdbc "0.5.1"]
                  [com.carouselapps/to-jdbc-uri "0.5.0"]
                  [seancorfield/next.jdbc "1.1.613"]


### PR DESCRIPTION
As said in https://www.hugsql.org/#adapter-default the hugsql package is a meta package that includes `java.jdbc` package by default. As we moved to `next.jdbc`, we'd better use `hugsql-core` here to avoid inclusion of `java.jdbc` any more.